### PR TITLE
Drop signal locks

### DIFF
--- a/sdr/include/flow/decimation.h
+++ b/sdr/include/flow/decimation.h
@@ -19,7 +19,7 @@ class decimator : public flow<T_in, T_out> {
   T_out decimated_buffer[MAXIMUM_BUFFER_LENGTH];
 
   void process_buffer() override;
-  virtual int decimate(int len) = 0;
+  virtual uint32_t decimate(int len) = 0;
 
  public:
   decimator(int m_factor, double fc, int kernel_length);
@@ -30,7 +30,7 @@ class complex_decimator : public decimator<T_in, T_out> {
  private:
   double acc_i;
   double acc_q;
-  int decimate(int len) override;
+  uint32_t decimate(int len) override;
 
  public:
   complex_decimator(int m_factor, double fc, int kernel_length);
@@ -40,7 +40,7 @@ template <class T_in, class T_out>
 class real_decimator : public decimator<T_in, T_out> {
  private:
   double acc;
-  int decimate(int len) override;
+  uint32_t decimate(int len) override;
 
  public:
   real_decimator(int m_factor, double fc, int kernel_length);

--- a/sdr/include/flow/decimation.h
+++ b/sdr/include/flow/decimation.h
@@ -16,10 +16,8 @@ class decimator : public flow<T_in, T_out> {
   std::vector<double> kernel;
 
   int window_cnt;
-  T_out decimated_buffer[MAXIMUM_BUFFER_LENGTH];
 
-  void process_buffer() override;
-  virtual uint32_t decimate(int len) = 0;
+  virtual uint32_t process_buffer(int len) = 0;
 
  public:
   decimator(int m_factor, double fc, int kernel_length);
@@ -30,7 +28,7 @@ class complex_decimator : public decimator<T_in, T_out> {
  private:
   double acc_i;
   double acc_q;
-  uint32_t decimate(int len) override;
+  uint32_t process_buffer(int len) override;
 
  public:
   complex_decimator(int m_factor, double fc, int kernel_length);
@@ -40,7 +38,7 @@ template <class T_in, class T_out>
 class real_decimator : public decimator<T_in, T_out> {
  private:
   double acc;
-  uint32_t decimate(int len) override;
+  uint32_t process_buffer(int len) override;
 
  public:
   real_decimator(int m_factor, double fc, int kernel_length);

--- a/sdr/include/flow/fm_demodulation.h
+++ b/sdr/include/flow/fm_demodulation.h
@@ -12,15 +12,12 @@ template <class T_in, class T_out>
 class fm_demodulator : public flow<T_in, T_out> {
  private:
   double prev_angle;
-  T_out demodulated_buffer[MAXIMUM_BUFFER_LENGTH];
 
-  void process_buffer() override;
-  uint32_t demodulate(int len);
+  uint32_t process_buffer(int len) override;
 
  public:
   fm_demodulator()
     : flow<T_in, T_out>(),
-      demodulated_buffer {0},
       prev_angle {0} {};
 };
 

--- a/sdr/include/flow/fm_demodulation.h
+++ b/sdr/include/flow/fm_demodulation.h
@@ -15,7 +15,7 @@ class fm_demodulator : public flow<T_in, T_out> {
   T_out demodulated_buffer[MAXIMUM_BUFFER_LENGTH];
 
   void process_buffer() override;
-  int demodulate(int len);
+  uint32_t demodulate(int len);
 
  public:
   fm_demodulator()

--- a/sdr/include/ring_buffer.h
+++ b/sdr/include/ring_buffer.h
@@ -24,15 +24,15 @@ class buffer_empty_exception : public std::runtime_error {
 template <class T>
 class ring_buffer {
  private:
-  std::mutex m;
-  bool read_c, write_c;
-  std::condition_variable read_v, write_v;
-
   bool empty;
   int head, tail, read_offset, size;
   std::vector<T> buffer;
 
  public:
+  std::mutex m;
+  bool read_c, write_c;
+  std::condition_variable read_v, write_v;
+
   ring_buffer()
     : buffer (MAXIMUM_BUFFER_LENGTH, 0),
       head {0},
@@ -69,8 +69,10 @@ class ring_buffer {
     signal_lock(signal_lock && lock);
   };
 
-  signal_lock read_lock();
-  signal_lock write_lock();
+  void read_release();
+  void write_release();
+  //signal_lock read_lock();
+  //signal_lock write_lock();
 
 
   /* Buffer data access */

--- a/sdr/include/ring_buffer.h
+++ b/sdr/include/ring_buffer.h
@@ -8,18 +8,6 @@
 #include "const.h"
 
 
-class buffer_full_exception : public std::runtime_error {
- public:
-  buffer_full_exception() :
-      std::runtime_error("Buffer full!") {};
-};
-
-class buffer_empty_exception : public std::runtime_error {
- public:
-  buffer_empty_exception() :
-      std::runtime_error("Buffer empty!") {};
-};
-
 template <class T>
 struct mem_block {
   T * start_index;

--- a/sdr/include/ring_buffer.h
+++ b/sdr/include/ring_buffer.h
@@ -31,14 +31,13 @@ struct mem_block {
 template <class T>
 class ring_buffer {
  private:
-  bool read_c;
-  std::condition_variable read_v;
-
   uint32_t head, tail, size, s_mask, b_mask;
   std::vector<T> buffer;
 
  public:
   std::mutex m;
+  std::condition_variable read_v;
+  bool read_c;
 
   ring_buffer()
     : buffer (2 * MAXIMUM_BUFFER_LENGTH, 0),
@@ -48,30 +47,6 @@ class ring_buffer {
       b_mask {2 * MAXIMUM_BUFFER_LENGTH - 1},
       size {MAXIMUM_BUFFER_LENGTH},
       read_c {false} {};
-
-  int get_size();
-
-  /* Buffer access synchronization */
-
-  class signal_lock {
-   private:
-    std::unique_lock<std::mutex> lck;
-    std::condition_variable & final_cond;
-    bool & final_flag;
-
-   public:
-    signal_lock(
-        std::mutex & m,
-        std::condition_variable & final_cond,
-        bool & final_flag);
-    ~signal_lock();
-    signal_lock(signal_lock && lock);
-  };
-
-  void read_lock(std::unique_lock<std::mutex> & m);
-  void read_release();
-  signal_lock write_lock();
-
 
   /* Buffer data access */
   int available_read();

--- a/sdr/include/ring_buffer.h
+++ b/sdr/include/ring_buffer.h
@@ -24,15 +24,15 @@ class buffer_empty_exception : public std::runtime_error {
 template <class T>
 class ring_buffer {
  private:
+  std::mutex m;
+  bool read_c, write_c;
+  std::condition_variable read_v, write_v;
+
   bool empty;
   int head, tail, read_offset, size;
   std::vector<T> buffer;
 
  public:
-  std::mutex m;
-  bool read_c, write_c;
-  std::condition_variable read_v, write_v;
-
   ring_buffer()
     : buffer (MAXIMUM_BUFFER_LENGTH, 0),
       head {0},
@@ -69,10 +69,8 @@ class ring_buffer {
     signal_lock(signal_lock && lock);
   };
 
-  void read_release();
-  void write_release();
-  //signal_lock read_lock();
-  //signal_lock write_lock();
+  signal_lock read_lock();
+  signal_lock write_lock();
 
 
   /* Buffer data access */

--- a/sdr/src/flow/decimation.cpp
+++ b/sdr/src/flow/decimation.cpp
@@ -38,9 +38,11 @@ template <typename T_in, typename T_out>
 void decimator<T_in, T_out>::process_buffer() {
   int len;
   {
-    auto lock = this->input_buffer->read_lock();
+    std::unique_lock<std::mutex> l(this->input_buffer->m);
+    this->input_buffer->read_lock(l);
     int to_read = this->input_buffer->available_read();
     len = decimate(to_read);
+    this->input_buffer->read_release();
   }
 
   auto lock = this->output_buffer->write_lock();

--- a/sdr/src/flow/decimation.cpp
+++ b/sdr/src/flow/decimation.cpp
@@ -37,17 +37,21 @@ decimator<T_in, T_out>::decimator(int m_factor, double fc, int kernel_length)
 template <typename T_in, typename T_out>
 void decimator<T_in, T_out>::process_buffer() {
   uint32_t len;
-  {
-    std::unique_lock<std::mutex> l(this->input_buffer->m);
-    this->input_buffer->read_lock(l);
-    int to_read = this->input_buffer->available_read();
-    len = decimate(to_read);
-    this->input_buffer->read_release();
-  }
+  std::unique_lock<std::mutex> r_lock(this->input_buffer->m);
+  this->input_buffer->read_v.wait(r_lock, [this] { return this->input_buffer->read_c; });
+  int to_read = this->input_buffer->available_read();
+  len = decimate(to_read);
 
-  auto lock = this->output_buffer->write_lock();
+  std::unique_lock<std::mutex> w_lock(this->output_buffer->m);
   mem_block<T_out> b = {decimated_buffer, len};
   this->output_buffer->push_block(b);
+
+  this->output_buffer->read_c = true;
+  w_lock.unlock();
+  this->output_buffer->read_v.notify_one();
+
+  this->input_buffer->read_c = false;
+  r_lock.unlock();
 }
 
 template <typename T_in, typename T_out>

--- a/sdr/src/flow/decimation.cpp
+++ b/sdr/src/flow/decimation.cpp
@@ -38,16 +38,20 @@ template <typename T_in, typename T_out>
 void decimator<T_in, T_out>::process_buffer() {
   int len;
   {
-    auto lock = this->input_buffer->read_lock();
+    std::unique_lock<std::mutex> lock(this->input_buffer->m);
+    this->input_buffer->read_v.wait(lock, [this] { return this->input_buffer->read_c; });
     int to_read = this->input_buffer->available_read();
     len = decimate(to_read);
+    this->input_buffer->read_release();
   }
 
-  auto lock = this->output_buffer->write_lock();
+  std::unique_lock<std::mutex> lock(this->output_buffer->m);
+  this->output_buffer->write_v.wait(lock, [this] { return this->output_buffer->write_c; });
   int to_write = this->output_buffer->available_write();
   for (int i = 0; i < std::min(len, to_write); i++) {
     this->output_buffer->push(decimated_buffer[i]);
   }
+  this->output_buffer->write_release();
 }
 
 template <typename T_in, typename T_out>

--- a/sdr/src/flow/fm_demodulation.cpp
+++ b/sdr/src/flow/fm_demodulation.cpp
@@ -4,21 +4,7 @@
 
 
 template <typename T_in, typename T_out>
-void fm_demodulator<T_in, T_out>::process_buffer() {
-  uint32_t len;
-  auto r_lock = this->input_buffer->read_lock();
-  int to_read = this->input_buffer->available_read();
-  len = demodulate(to_read);
-
-  {
-    auto w_lock = this->output_buffer->write_lock();
-    mem_block<T_out> b = {demodulated_buffer, len};
-    this->output_buffer->push_block(b);
-  }
-}
-
-template <typename T_in, typename T_out>
-uint32_t fm_demodulator<T_in, T_out>::demodulate(int len) {
+uint32_t fm_demodulator<T_in, T_out>::process_buffer(int len) {
   int i;
 
   for (i = 0; i < len; i += 2) {
@@ -31,7 +17,7 @@ uint32_t fm_demodulator<T_in, T_out>::demodulate(int len) {
     else if (angle_diff < -PI)
       angle_diff = -2 * PI - angle_diff;
 
-    demodulated_buffer[i / 2] = angle_diff / PI * (1u << 15u);
+    this->intermediate_buffer[i / 2] = angle_diff / PI * (1u << 15u);
     prev_angle = angle;
   }
   this->input_buffer->advance_head(i);

--- a/sdr/src/flow/fm_demodulation.cpp
+++ b/sdr/src/flow/fm_demodulation.cpp
@@ -6,17 +6,21 @@
 template <typename T_in, typename T_out>
 void fm_demodulator<T_in, T_out>::process_buffer() {
   uint32_t len;
-  {
-    std::unique_lock<std::mutex> l(this->input_buffer->m);
-    this->input_buffer->read_lock(l);
-    int to_read = this->input_buffer->available_read();
-    len = demodulate(to_read);
-    this->input_buffer->read_release();
-  }
+  std::unique_lock<std::mutex> r_lock(this->input_buffer->m);
+  this->input_buffer->read_v.wait(r_lock, [this] { return this->input_buffer->read_c; });
+  int to_read = this->input_buffer->available_read();
+  len = demodulate(to_read);
 
-  auto lock = this->output_buffer->write_lock();
-  mem_block<T_out> b = {demodulated_buffer, len };
+  std::unique_lock<std::mutex> w_lock(this->output_buffer->m);
+  mem_block<T_out> b = {demodulated_buffer, len};
   this->output_buffer->push_block(b);
+
+  this->output_buffer->read_c = true;
+  w_lock.unlock();
+  this->output_buffer->read_v.notify_one();
+
+  this->input_buffer->read_c = false;
+  r_lock.unlock();
 }
 
 template <typename T_in, typename T_out>
@@ -36,7 +40,7 @@ uint32_t fm_demodulator<T_in, T_out>::demodulate(int len) {
     demodulated_buffer[i / 2] = angle_diff / PI * (1u << 15u);
     prev_angle = angle;
   }
-  this->input_buffer->advance_head(len);
+  this->input_buffer->advance_head(i);
 
   return int (i / 2);
 }

--- a/sdr/src/flow/fm_demodulation.cpp
+++ b/sdr/src/flow/fm_demodulation.cpp
@@ -7,9 +7,11 @@ template <typename T_in, typename T_out>
 void fm_demodulator<T_in, T_out>::process_buffer() {
   int len;
   {
-    auto lock = this->input_buffer->read_lock();
+    std::unique_lock<std::mutex> l(this->input_buffer->m);
+    this->input_buffer->read_lock(l);
     int to_read = this->input_buffer->available_read();
     len = demodulate(to_read);
+    this->input_buffer->read_release();
   }
 
   auto lock = this->output_buffer->write_lock();

--- a/sdr/src/flow/fm_demodulation.cpp
+++ b/sdr/src/flow/fm_demodulation.cpp
@@ -6,21 +6,15 @@
 template <typename T_in, typename T_out>
 void fm_demodulator<T_in, T_out>::process_buffer() {
   uint32_t len;
-  std::unique_lock<std::mutex> r_lock(this->input_buffer->m);
-  this->input_buffer->read_v.wait(r_lock, [this] { return this->input_buffer->read_c; });
+  auto r_lock = this->input_buffer->read_lock();
   int to_read = this->input_buffer->available_read();
   len = demodulate(to_read);
 
-  std::unique_lock<std::mutex> w_lock(this->output_buffer->m);
-  mem_block<T_out> b = {demodulated_buffer, len};
-  this->output_buffer->push_block(b);
-
-  this->output_buffer->read_c = true;
-  w_lock.unlock();
-  this->output_buffer->read_v.notify_one();
-
-  this->input_buffer->read_c = false;
-  r_lock.unlock();
+  {
+    auto w_lock = this->output_buffer->write_lock();
+    mem_block<T_out> b = {demodulated_buffer, len};
+    this->output_buffer->push_block(b);
+  }
 }
 
 template <typename T_in, typename T_out>

--- a/sdr/src/flow/fm_demodulation.cpp
+++ b/sdr/src/flow/fm_demodulation.cpp
@@ -7,20 +7,16 @@ template <typename T_in, typename T_out>
 void fm_demodulator<T_in, T_out>::process_buffer() {
   int len;
   {
-    std::unique_lock<std::mutex> lock(this->input_buffer->m);
-    this->input_buffer->read_v.wait(lock, [this] { return this->input_buffer->read_c; });
+    auto lock = this->input_buffer->read_lock();
     int to_read = this->input_buffer->available_read();
     len = demodulate(to_read);
-    this->input_buffer->read_release();
   }
 
-  std::unique_lock<std::mutex> lock(this->output_buffer->m);
-  this->output_buffer->write_v.wait(lock, [this] { return this->output_buffer->write_c; });
+  auto lock = this->output_buffer->write_lock();
   int to_write = this->output_buffer->available_write();
   for (int i = 0; i < std::min(len, to_write); i++) {
     this->output_buffer->push(demodulated_buffer[i]);
   }
-  this->output_buffer->write_release();
 }
 
 template <typename T_in, typename T_out>

--- a/sdr/src/main.cpp
+++ b/sdr/src/main.cpp
@@ -3,7 +3,7 @@
 int main(int argc, char * argv[]) {
   uint32_t dev_index = 0;
   int freq = 101596000, sampling_rate = 2400000;
-  int kernel_length1 = 257, kernel_length2 = 257;
+  int kernel_length1 = 129, kernel_length2 = 257;
   std::string source = "../data/iq_speech";
   std::string target = std::string(argv[1]);
 

--- a/sdr/src/main.cpp
+++ b/sdr/src/main.cpp
@@ -4,7 +4,7 @@ int main(int argc, char * argv[]) {
   uint32_t dev_index = 0;
   int freq = 101596000, sampling_rate = 2400000;
   int kernel_length1 = 129, kernel_length2 = 257;
-  std::string source = "../data/iq_music";
+  std::string source = "../data/iq_speech";
   std::string target = std::string(argv[1]);
 
   //iq_writer recv(dev_index, freq, sampling_rate, source, target);

--- a/sdr/src/main.cpp
+++ b/sdr/src/main.cpp
@@ -4,7 +4,7 @@ int main(int argc, char * argv[]) {
   uint32_t dev_index = 0;
   int freq = 101596000, sampling_rate = 2400000;
   int kernel_length1 = 129, kernel_length2 = 257;
-  std::string source = "../data/iq_speech";
+  std::string source = "../data/iq_music";
   std::string target = std::string(argv[1]);
 
   //iq_writer recv(dev_index, freq, sampling_rate, source, target);

--- a/sdr/src/ring_buffer.cpp
+++ b/sdr/src/ring_buffer.cpp
@@ -51,18 +51,34 @@ int ring_buffer<T>::get_read_offset() {
   return read_offset;
 }
 
-template <class T>
-typename ring_buffer<T>::signal_lock ring_buffer<T>::read_lock()
-{
-  ring_buffer<T>::signal_lock l(m, read_v, read_c, write_v, write_c);
-  return l;
-}
+//template <class T>
+//typename ring_buffer<T>::signal_lock ring_buffer<T>::read_lock()
+//{
+//  ring_buffer<T>::signal_lock l(m, read_v, read_c, write_v, write_c);
+//  return l;
+//}
+//
+//template <class T>
+//typename ring_buffer<T>::signal_lock ring_buffer<T>::write_lock()
+//{
+//  ring_buffer<T>::signal_lock l(m, write_v, write_c, read_v, read_c);
+//  return l;
+//}
+
 
 template <class T>
-typename ring_buffer<T>::signal_lock ring_buffer<T>::write_lock()
-{
-  ring_buffer<T>::signal_lock l(m, write_v, write_c, read_v, read_c);
-  return l;
+void ring_buffer<T>::read_release() {
+  write_c = true;
+  write_v.notify_one();
+  read_c = false;
+}
+
+
+template <class T>
+void ring_buffer<T>::write_release() {
+  read_c = true;
+  read_v.notify_one();
+  write_c = false;
 }
 
 template <class T>

--- a/sdr/src/ring_buffer.cpp
+++ b/sdr/src/ring_buffer.cpp
@@ -3,56 +3,7 @@
 #include <cstring>
 #include "ring_buffer.h"
 
-
-/* signal_lock */
-
-template <class T>
-ring_buffer<T>::signal_lock::signal_lock(
-    std::mutex & m,
-    std::condition_variable & final_cond,
-    bool & final_flag)
-    : lck (m),
-      final_cond {final_cond},
-      final_flag {final_flag} {};
-
-
-template <class T>
-ring_buffer<T>::signal_lock::~signal_lock() {
-  final_flag = true;
-  lck.unlock();
-  final_cond.notify_all();
-}
-
-template<class T>
-ring_buffer<T>::signal_lock::signal_lock(ring_buffer<T>::signal_lock && other)
-  : lck(std::move(other.lck)),
-    final_cond {other.final_cond},
-    final_flag {other.final_flag} {};
-
-
 /* ring_buffer */
-
-template <class T>
-int ring_buffer<T>::get_size() { return size; }
-
-template <class T>
-void ring_buffer<T>::read_lock(std::unique_lock<std::mutex> & lock)
-{
-  read_v.wait(lock, [this] { return read_c; });
-}
-
-template <class T>
-void ring_buffer<T>::read_release()
-{
-  read_c = false;
-}
-
-template <class T>
-typename ring_buffer<T>::signal_lock ring_buffer<T>::write_lock()
-{
-  ring_buffer<T>::signal_lock l(m, read_v, read_c);
-  return l;
-}
 
 /*
  * Bit magic picked up from https://github.com/JvanKatwijk/sdr-j-fm RingBuffer implementation.

--- a/sdr/src/ring_buffer.cpp
+++ b/sdr/src/ring_buffer.cpp
@@ -51,34 +51,18 @@ int ring_buffer<T>::get_read_offset() {
   return read_offset;
 }
 
-//template <class T>
-//typename ring_buffer<T>::signal_lock ring_buffer<T>::read_lock()
-//{
-//  ring_buffer<T>::signal_lock l(m, read_v, read_c, write_v, write_c);
-//  return l;
-//}
-//
-//template <class T>
-//typename ring_buffer<T>::signal_lock ring_buffer<T>::write_lock()
-//{
-//  ring_buffer<T>::signal_lock l(m, write_v, write_c, read_v, read_c);
-//  return l;
-//}
-
-
 template <class T>
-void ring_buffer<T>::read_release() {
-  write_c = true;
-  write_v.notify_one();
-  read_c = false;
+typename ring_buffer<T>::signal_lock ring_buffer<T>::read_lock()
+{
+  ring_buffer<T>::signal_lock l(m, read_v, read_c, write_v, write_c);
+  return l;
 }
 
-
 template <class T>
-void ring_buffer<T>::write_release() {
-  read_c = true;
-  read_v.notify_one();
-  write_c = false;
+typename ring_buffer<T>::signal_lock ring_buffer<T>::write_lock()
+{
+  ring_buffer<T>::signal_lock l(m, write_v, write_c, read_v, read_c);
+  return l;
 }
 
 template <class T>

--- a/sdr/src/sink/file_sink.cpp
+++ b/sdr/src/sink/file_sink.cpp
@@ -19,12 +19,14 @@ template <typename T>
 void file_sink<T>::worker() {
   int i = 0;
   while (working) {
-    auto lock = this->input_buffer->read_lock();
+    std::unique_lock<std::mutex> l(this->input_buffer->m);
+    this->input_buffer->read_lock(l);
     auto b = this->input_buffer->take_block();
 
     (*target).write(reinterpret_cast<const char *>(b.start_index), b.length * sizeof(T));
     this->input_buffer->move_read_index(b.length);
     this->input_buffer->advance_head();
+    this->input_buffer->read_release();
     //std::cerr << "read " << b.length << " at " << this->input_buffer->get_read_offset() << std::endl;
   }
 }

--- a/sdr/src/sink/file_sink.cpp
+++ b/sdr/src/sink/file_sink.cpp
@@ -19,16 +19,12 @@ template <typename T>
 void file_sink<T>::worker() {
   int i = 0;
   while (working) {
-    std::unique_lock<std::mutex> lock(this->input_buffer->m);
-    this->input_buffer->read_v.wait(lock, [this] { return this->input_buffer->read_c; });
-
+    auto lock = this->input_buffer->read_lock();
     auto b = this->input_buffer->take_block();
 
     (*target).write(reinterpret_cast<const char *>(b.start_index), b.length * sizeof(T));
     this->input_buffer->move_read_index(b.length);
     this->input_buffer->advance_head();
-
-    this->input_buffer->read_release();
     //std::cerr << "read " << b.length << " at " << this->input_buffer->get_read_offset() << std::endl;
   }
 }

--- a/sdr/src/sink/file_sink.cpp
+++ b/sdr/src/sink/file_sink.cpp
@@ -19,15 +19,11 @@ template <typename T>
 void file_sink<T>::worker() {
   int i = 0;
   while (working) {
-    std::unique_lock<std::mutex> lock(this->input_buffer->m);
-    this->input_buffer->read_v.wait(lock, [this] { return this->input_buffer->read_c; });
+    auto r_lock = this->input_buffer->read_lock();
     auto b = this->input_buffer->take_block();
 
     (*target).write(reinterpret_cast<const char *>(b.start_index), b.length * sizeof(T));
     this->input_buffer->advance_head(b.length);
-
-    this->input_buffer->read_c = false;
-    lock.unlock();
   }
 }
 

--- a/sdr/src/sink/file_sink.cpp
+++ b/sdr/src/sink/file_sink.cpp
@@ -19,12 +19,16 @@ template <typename T>
 void file_sink<T>::worker() {
   int i = 0;
   while (working) {
-    auto lock = this->input_buffer->read_lock();
+    std::unique_lock<std::mutex> lock(this->input_buffer->m);
+    this->input_buffer->read_v.wait(lock, [this] { return this->input_buffer->read_c; });
+
     auto b = this->input_buffer->take_block();
 
     (*target).write(reinterpret_cast<const char *>(b.start_index), b.length * sizeof(T));
     this->input_buffer->move_read_index(b.length);
     this->input_buffer->advance_head();
+
+    this->input_buffer->read_release();
     //std::cerr << "read " << b.length << " at " << this->input_buffer->get_read_offset() << std::endl;
   }
 }

--- a/sdr/src/sink/file_sink.cpp
+++ b/sdr/src/sink/file_sink.cpp
@@ -24,10 +24,8 @@ void file_sink<T>::worker() {
     auto b = this->input_buffer->take_block();
 
     (*target).write(reinterpret_cast<const char *>(b.start_index), b.length * sizeof(T));
-    this->input_buffer->move_read_index(b.length);
-    this->input_buffer->advance_head();
+    this->input_buffer->advance_head(b.length);
     this->input_buffer->read_release();
-    //std::cerr << "read " << b.length << " at " << this->input_buffer->get_read_offset() << std::endl;
   }
 }
 

--- a/sdr/src/source/file_source.cpp
+++ b/sdr/src/source/file_source.cpp
@@ -5,7 +5,8 @@
 
 void file_source::worker() {
   while (working && source_file.read(reinterpret_cast<char *>(im_buffer), DEFAULT_BUFFER_LENGTH * sizeof(int16_t))) {
-    auto lock = output_buffer->write_lock();
+    std::unique_lock<std::mutex> lock(this->output_buffer->m);
+    this->output_buffer->write_v.wait(lock, [this] { return this->output_buffer->write_c; });
 
     unsigned long available = output_buffer->available_write();
     unsigned long count = source_file.gcount() / sizeof(int16_t);
@@ -13,6 +14,7 @@ void file_source::worker() {
     for (unsigned long i = 0; i < std::min(count, available); i++) {
       output_buffer->push(im_buffer[i]);
     }
+    this->output_buffer->write_release();
   }
 
   std::cerr << "Done! " << std::endl;

--- a/sdr/src/source/file_source.cpp
+++ b/sdr/src/source/file_source.cpp
@@ -5,8 +5,7 @@
 
 void file_source::worker() {
   while (working && source_file.read(reinterpret_cast<char *>(im_buffer), DEFAULT_BUFFER_LENGTH * sizeof(int16_t))) {
-    std::unique_lock<std::mutex> lock(this->output_buffer->m);
-    this->output_buffer->write_v.wait(lock, [this] { return this->output_buffer->write_c; });
+    auto lock = output_buffer->write_lock();
 
     unsigned long available = output_buffer->available_write();
     unsigned long count = source_file.gcount() / sizeof(int16_t);
@@ -14,7 +13,6 @@ void file_source::worker() {
     for (unsigned long i = 0; i < std::min(count, available); i++) {
       output_buffer->push(im_buffer[i]);
     }
-    this->output_buffer->write_release();
   }
 
   std::cerr << "Done! " << std::endl;

--- a/sdr/src/source/file_source.cpp
+++ b/sdr/src/source/file_source.cpp
@@ -7,12 +7,9 @@ void file_source::worker() {
   while (working && source_file.read(reinterpret_cast<char *>(im_buffer), DEFAULT_BUFFER_LENGTH * sizeof(int16_t))) {
     auto lock = output_buffer->write_lock();
 
-    unsigned long available = output_buffer->available_write();
-    unsigned long count = source_file.gcount() / sizeof(int16_t);
-
-    for (unsigned long i = 0; i < std::min(count, available); i++) {
-      output_buffer->push(im_buffer[i]);
-    }
+    uint32_t count = source_file.gcount() / sizeof(int16_t);
+    mem_block<int16_t> b = {im_buffer, count};
+    output_buffer->push_block(b);
   }
 
   std::cerr << "Done! " << std::endl;

--- a/sdr/src/source/file_source.cpp
+++ b/sdr/src/source/file_source.cpp
@@ -7,15 +7,11 @@
 void file_source::worker() {
   while (working && source_file.read(reinterpret_cast<char *>(im_buffer), DEFAULT_BUFFER_LENGTH * sizeof(int16_t))) {
     usleep(100);  // don't make aplay choke with too high sample rate
-    std::unique_lock<std::mutex> lock(this->output_buffer->m);
+    auto w_lock = this->output_buffer->write_lock();
 
     uint32_t count = source_file.gcount() / sizeof(int16_t);
     mem_block<int16_t> b = {im_buffer, count};
     output_buffer->push_block(b);
-
-    this->output_buffer->read_c = true;
-    lock.unlock();
-    this->output_buffer->read_v.notify_one();
   }
 
   std::cerr << "Done! " << std::endl;

--- a/sdr/src/source/file_source.cpp
+++ b/sdr/src/source/file_source.cpp
@@ -1,15 +1,21 @@
 #include <iostream>
 #include <algorithm>
+#include <unistd.h>
 #include "source/file_source.h"
 
 
 void file_source::worker() {
   while (working && source_file.read(reinterpret_cast<char *>(im_buffer), DEFAULT_BUFFER_LENGTH * sizeof(int16_t))) {
-    auto lock = output_buffer->write_lock();
+    usleep(100);  // don't make aplay choke with too high sample rate
+    std::unique_lock<std::mutex> lock(this->output_buffer->m);
 
     uint32_t count = source_file.gcount() / sizeof(int16_t);
     mem_block<int16_t> b = {im_buffer, count};
     output_buffer->push_block(b);
+
+    this->output_buffer->read_c = true;
+    lock.unlock();
+    this->output_buffer->read_v.notify_one();
   }
 
   std::cerr << "Done! " << std::endl;

--- a/sdr/src/source/rtl_source.cpp
+++ b/sdr/src/source/rtl_source.cpp
@@ -42,12 +42,10 @@ void rtl_source::stop() {
 
 extern "C" void rtlsdr_callback(unsigned char * buf, uint32_t len, void *ctx) {
   auto source = (rtl_source*) ctx;
-  std::unique_lock<std::mutex> lock(source->output_buffer->m);
-  source->output_buffer->write_v.wait(lock, [source] { return source->output_buffer->write_c; });
+  source->output_buffer->write_lock();
 
   int available = source->output_buffer->available_write();
   for (int i = 0; i < std::min((int)len, available); i++) {
     source->output_buffer->push((int16_t)buf[i] - 127);
   }
-  source->output_buffer->write_release();
 }

--- a/sdr/src/source/rtl_source.cpp
+++ b/sdr/src/source/rtl_source.cpp
@@ -42,14 +42,10 @@ void rtl_source::stop() {
 
 extern "C" void rtlsdr_callback(unsigned char * buf, uint32_t len, void *ctx) {
   auto source = (rtl_source*) ctx;
-  std::unique_lock<std::mutex> lock(source->output_buffer->m);
+  auto r_lock = source->output_buffer->write_lock();
 
   int available = source->output_buffer->available_write();
   for (int i = 0; i < std::min((int)len, available); i++) {
     source->output_buffer->push((int16_t)buf[i] - 127);
   }
-
-  source->output_buffer->read_c = true;
-  lock.unlock();
-  source->output_buffer->read_v.notify_one();
 }

--- a/sdr/src/source/rtl_source.cpp
+++ b/sdr/src/source/rtl_source.cpp
@@ -42,10 +42,14 @@ void rtl_source::stop() {
 
 extern "C" void rtlsdr_callback(unsigned char * buf, uint32_t len, void *ctx) {
   auto source = (rtl_source*) ctx;
-  source->output_buffer->write_lock();
+  std::unique_lock<std::mutex> lock(source->output_buffer->m);
 
   int available = source->output_buffer->available_write();
   for (int i = 0; i < std::min((int)len, available); i++) {
     source->output_buffer->push((int16_t)buf[i] - 127);
   }
+
+  source->output_buffer->read_c = true;
+  lock.unlock();
+  source->output_buffer->read_v.notify_one();
 }

--- a/sdr/src/source/rtl_source.cpp
+++ b/sdr/src/source/rtl_source.cpp
@@ -42,10 +42,12 @@ void rtl_source::stop() {
 
 extern "C" void rtlsdr_callback(unsigned char * buf, uint32_t len, void *ctx) {
   auto source = (rtl_source*) ctx;
-  source->output_buffer->write_lock();
+  std::unique_lock<std::mutex> lock(source->output_buffer->m);
+  source->output_buffer->write_v.wait(lock, [source] { return source->output_buffer->write_c; });
 
   int available = source->output_buffer->available_write();
   for (int i = 0; i < std::min((int)len, available); i++) {
     source->output_buffer->push((int16_t)buf[i] - 127);
   }
+  source->output_buffer->write_release();
 }


### PR DESCRIPTION
Don't drop the locks after all, they're cool. Suspicion is that some memcpy operations on the buffer itself should (somehow?) be optimized.